### PR TITLE
Adapting APEX build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -623,17 +623,33 @@ endif()
 ################################################################################
 # Enable integration with Apex event counters
 ################################################################################
+set(HPX_ADDITIONAL_RUNTIME_DEPENDENCIES CACHE INTERNAL "")
 if(HPX_WITH_APEX)
-  find_package(APEX)
+  # handle APEX library
+  add_subdirectory(apex/apex)
   if(NOT APEX_FOUND)
-    hpx_error("Apex could not be found and HPX_WITH_APEX=On, please specify APEX_ROOT to point to the root of your Apex installation")
+    hpx_error("Apex could not be found and HPX_WITH_APEX=On")
   endif()
-  hpx_libraries(${APEX_LIBRARIES})
-  include_directories(${APEX_INCLUDE_DIR})
   if(AMPLIFIER_FOUND)
     hpx_error("AMPLIFIER_FOUND has been set. Please disable the use of the Intel Amplifier (WITH_AMPLIFIER=Off) in order to use Apex")
   endif()
-  hpx_add_config_define(HPX_HAVE_ITTNOTIFY)
+
+  include_directories(${APEX_SOURCE_DIR})
+  hpx_add_config_define(HPX_HAVE_APEX 1)
+  set(HPX_ADDITIONAL_RUNTIME_DEPENDENCIES
+      ${HPX_ADDITIONAL_RUNTIME_DEPENDENCIES} apex_lib)
+
+  # handle optional ITTNotify library
+  if(HPX_WITH_ITTNOTIFY)
+    add_subdirectory(apex/ITTNotify)
+    if(NOT ITTNOTIFY_FOUND)
+      hpx_error("ITTNotify could not be found and HPX_WITH_ITTNOTIFY=On")
+    endif()
+    include_directories(${ITTNOTIFY_SOURCE_DIR})
+    hpx_add_config_define(HPX_HAVE_ITTNOTIFY 1)
+    set(HPX_ADDITIONAL_RUNTIME_DEPENDENCIES
+        ${HPX_ADDITIONAL_RUNTIME_DEPENDENCIES} ittnotify_lib)
+  endif()
 endif()
 
 if(HPX_WITH_GOOGLE_PERFTOOLS)
@@ -1162,53 +1178,6 @@ set(HPX_DEBUG_POSTFIX "d")
 # Recurse into some subdirectories. This does not actually cause another cmake
 # executable to run. The same process will walk through the project's entire
 # directory structure.
-
-if(HPX_HAVE_APEX)
-  add_subdirectory(apex/apex)
-  set(APEX_BINARY_DIR ${PROJECT_BINARY_DIR}/lib)
-  set(ITTNOTIFY_BINARY_DIR ${PROJECT_BINARY_DIR}/lib)
-  hpx_info("apex" "Apex source dir: ${APEX_SOURCE_DIR}")
-  hpx_info("apex" "Apex binary dir: ${APEX_BINARY_DIR}")
-
-
-
-  set(APEX_FOUND ON)
-
-  if(NOT MSVC)
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-      set(apex_libraries
-        ${APEX_BINARY_DIR}/libapex${CMAKE_DEBUG_POSTFIX}.so
-        ${ITTNOTIFY_BINARY_DIR}/libittnotify${CMAKE_DEBUG_POSTFIX}.so)
-    else()
-      set(apex_libraries
-        ${APEX_BINARY_DIR}/libapex.so
-        ${ITTNOTIFY_BINARY_DIR}/libittnotify.so)
-    endif()
-  else()
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
-      set(apex_libraries
-        "${APEX_BINARY_DIR}/Debug/apex${CMAKE_DEBUG_POSTFIX}.lib"
-        "${ITTNOTIFY_BINARY_DIR}/Debug/ittnotify${CMAKE_DEBUG_POSTFIX}.lib")
-    else()
-      set(apex_libraries
-        "${APEX_BINARY_DIR}/${CMAKE_BUILD_TYPE}/apex.lib"
-        "${ITTNOTIFY_BINARY_DIR}/${CMAKE_BUILD_TYPE}/ittnotify.lib")
-    endif()
-  endif()
-  set(hpx_RUNTIME_LIBRARIES ${hpx_RUNTIME_LIBRARIES} ${apex_libraries})
-
-  hpx_info("apex" "Apex libraries: ${apex_libraries}")
-
-  include_directories(${APEX_SOURCE_DIR})
-  hpx_libraries(${apex_libraries})
-  #hpx_link_sys_directories(${APEX_BINARY_DIR})
-  hpx_add_config_define(HPX_HAVE_APEX)
-
-  include_directories(${ITTNOTIFY_SOURCE_DIR})
-  #hpx_link_sys_directories(${ITTNOTIFY_BINARY_DIR})
-  hpx_add_config_define(HPX_HAVE_ITTNOTIFY 1)
-endif()
-
 
 if(HPX_BUILD_TOOLS)
   add_hpx_pseudo_target(tools)

--- a/cmake/HPX_AddLibrary.cmake
+++ b/cmake/HPX_AddLibrary.cmake
@@ -81,6 +81,11 @@ macro(add_hpx_library name)
       TARGETS ${${name}_lib_HEADERS})
   endif()
 
+  set(_nolibs)
+  if(NOT ${name}_NOLIBS)
+    set(_nolibs NOLIBS)
+  endif()
+
   hpx_print_list("DEBUG" "add_library.${name}" "Sources for ${name}" ${name}_SOURCES)
   hpx_print_list("DEBUG" "add_library.${name}" "Headers for ${name}" ${name}_HEADERS)
   hpx_print_list("DEBUG" "add_library.${name}" "Dependencies for ${name}" ${name}_DEPENDENCIES)
@@ -161,6 +166,7 @@ macro(add_hpx_library name)
     LINK_FLAGS ${${name}_LINK_FLAGS}
     DEPENDENCIES ${${name}_DEPENDENCIES}
     COMPONENT_DEPENDENCIES ${${name}_COMPONENT_DEPENDENCIES}
+    ${_nolibs}
     ${_target_flags}
     ${install_optional}
   )

--- a/cmake/HPX_SetupTarget.cmake
+++ b/cmake/HPX_SetupTarget.cmake
@@ -156,7 +156,7 @@ function(hpx_setup_target target)
   # ABI differences
   if(CMAKE_MAJOR_VERSION GREATER 2)
     set_property(TARGET ${target} APPEND PROPERTY
-	    COMPILE_DEFINITIONS $<$<CONFIG:Debug>:HPX_DEBUG>)
+        COMPILE_DEFINITIONS $<$<CONFIG:Debug>:HPX_DEBUG>)
   else()
     set_property(TARGET ${target} APPEND PROPERTY
       COMPILE_DEFINITIONS_DEBUG HPX_DEBUG)

--- a/hpx/util/apex.hpp
+++ b/hpx/util/apex.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2013 Hartmut Kaiser
+//  Copyright (c) 2007-2015 Hartmut Kaiser
 //
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -12,7 +12,11 @@
 #endif
 
 #ifdef HPX_HAVE_APEX
+#ifdef HPX_HAVE_ITTNOTIFY
 extern bool use_ittnotify_api;
+#else
+static bool const use_ittnotify_api = true;
+#endif
 #endif
 
 namespace hpx { namespace util
@@ -34,8 +38,7 @@ namespace hpx { namespace util
     }
 
     struct apex_wrapper
-    {                      
-        
+    {
         apex_wrapper(char const* const name)
           : name_(name)
         {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -257,11 +257,13 @@ endif()
 
 if(HPX_STATIC_LINKING)
   target_link_libraries(hpx
-    ${HPX_LIBRARIES})
+    ${HPX_LIBRARIES}
+    ${HPX_ADDITIONAL_RUNTIME_DEPENDENCIES})
 else()
   target_link_libraries(hpx
     hpx_serialization
-    ${HPX_LIBRARIES})
+    ${HPX_LIBRARIES}
+    ${HPX_ADDITIONAL_RUNTIME_DEPENDENCIES})
 endif()
 
 set_property(TARGET hpx APPEND


### PR DESCRIPTION
This changes the HPX build system to work with new APEX. This relies on merging separate changes to the APEX master repository given by the following diff: https://gist.github.com/hkaiser/7dfef28a3e657670dbf8.
